### PR TITLE
Use a HEAD request

### DIFF
--- a/ChromiumForWindows-ungoogled/MainWindow.xaml.cs
+++ b/ChromiumForWindows-ungoogled/MainWindow.xaml.cs
@@ -88,6 +88,7 @@ namespace ChromiumForWindows
 
             // Checks the version from the website. It will use the link below, which will redirect to the latest version. string latestVersion will be equal to the redirected URL.
             WebRequest request = WebRequest.Create("https://github.com/macchrome/winchrome/releases/latest/");
+            request.Method = "HEAD"; // Use a HEAD request because we don't need to download the response body
             try
             {
                 using (WebResponse response = request.GetResponse())

--- a/ChromiumForWindows/MainWindow.xaml.cs
+++ b/ChromiumForWindows/MainWindow.xaml.cs
@@ -86,6 +86,7 @@ namespace ChromiumForWindows
 
             // Checks the version from the website. It will use the link below, which will redirect to the latest version. string latestVersion will be equal to the redirected URL.
             WebRequest request = WebRequest.Create("https://github.com/Hibbiki/chromium-win64/releases/latest/");
+            request.Method = "HEAD"; // Use a HEAD request because we don't need to download the response body
             try
             {
                 using (WebResponse response = request.GetResponse())


### PR DESCRIPTION
Use a HEAD request (instead of a GET request) because we don't need to download the response body, which should help optimize the launch time and network usage when checking for updates.