### PR TITLE
Only end Chrome processes that are managed by this updater

### DIFF
--- a/ChromiumForWindows-ungoogled/Update.cs
+++ b/ChromiumForWindows-ungoogled/Update.cs
@@ -18,8 +18,11 @@ namespace ChromiumForWindows
             Process[] processes = Process.GetProcessesByName("Chrome");
             foreach (var process in processes)
             {
-                process.Kill();
-                Console.WriteLine("Chromium process killed!");
+                if (process.MainModule.FileName.StartsWith(MainWindow.chromiumPath))
+                {
+                    process.Kill();
+                    Console.WriteLine("Chromium process killed!");
+                }
             }
 
             // Deletes old installer if exists:

--- a/ChromiumForWindows/Update.cs
+++ b/ChromiumForWindows/Update.cs
@@ -16,8 +16,11 @@ namespace ChromiumForWindows
             Process[] processes = Process.GetProcessesByName("Chrome");
             foreach (var process in processes)
             {
-                process.Kill();
-                Console.WriteLine("Chromium process killed!");
+                if (process.MainModule.FileName.StartsWith(MainWindow.chromiumPath))
+                {
+                    process.Kill();
+                    Console.WriteLine("Chromium process killed!");
+                }
             }
 
             // Deletes old installer if exists:


### PR DESCRIPTION
During update, instead of ending all "Chrome" processes on the system, only end the ones that are managed by this updater. This is done by checking the file path of the processes before ending them.